### PR TITLE
Show UI while loading store

### DIFF
--- a/packages/examples/grid/src/components/DataGenerator.tsx
+++ b/packages/examples/grid/src/components/DataGenerator.tsx
@@ -77,6 +77,7 @@ export function DataGenerator() {
         <div css={menu(menuOpen)}>
           {[100, 1000, 10000].map(rows => (
             <button
+              key={rows}
               css={styles.menuItem}
               role="button"
               type="button"

--- a/packages/examples/grid/src/components/Shell.tsx
+++ b/packages/examples/grid/src/components/Shell.tsx
@@ -24,8 +24,9 @@ export const Shell = () => {
   return (
     <div css={styles.shell}>
       <Toolbar cevitxe={cevitxe} onStoreReady={onStoreReady} />
-      {!appStore && <Loading />}
-      {appStore && (
+      {appStore === undefined ? (
+        <Loading />
+      ) : (
         <Provider store={appStore}>
           <DialogProvider>
             <App />

--- a/packages/examples/grid/src/components/Shell.tsx
+++ b/packages/examples/grid/src/components/Shell.tsx
@@ -17,7 +17,7 @@ export const Shell = () => {
   const [appStore, setAppStore] = useState<Redux.Store>()
 
   const onStoreReady = (store: Redux.Store) => {
-    log('store ready', cevitxe.documentId, store.getState()._testId)
+    log('store ready', cevitxe.documentId)
     setAppStore(store)
   }
 

--- a/packages/examples/grid/src/components/Shell.tsx
+++ b/packages/examples/grid/src/components/Shell.tsx
@@ -9,6 +9,7 @@ import { Provider } from 'react-redux'
 import Redux from 'redux'
 import { cevitxe } from 'src/redux/store'
 import { App } from './App'
+import { Loading } from './Loading'
 
 const log = debug('cevitxe:grid:shell')
 
@@ -23,6 +24,7 @@ export const Shell = () => {
   return (
     <div css={styles.shell}>
       <Toolbar cevitxe={cevitxe} onStoreReady={onStoreReady} />
+      {!appStore && <Loading />}
       {appStore && (
         <Provider store={appStore}>
           <DialogProvider>

--- a/packages/toolbar/src/Toolbar.tsx
+++ b/packages/toolbar/src/Toolbar.tsx
@@ -71,88 +71,81 @@ export const Toolbar = ({ cevitxe, onStoreReady }: ToolbarProps<any>) => {
 
   return (
     <div css={styles.toolbar}>
-      {appStore && (
-        <Formik initialValues={{ documentId }} onSubmit={() => load(documentId)}>
-          {({ values }) => {
-            const newClick = async () => {
-              const newDocumentId = await createStore()
-              setTimeout(() => load(newDocumentId), 200)
+      <Formik initialValues={{ documentId }} onSubmit={() => load(documentId)}>
+        {({ values }) => {
+          const newClick = async () => {
+            const newDocumentId = await createStore()
+            setTimeout(() => load(newDocumentId), 200)
+          }
+
+          const inputFocus = (e: Event) => {
+            if (e && e.target) {
+              const input = e.target as HTMLInputElement
+              input.select()
             }
+            setInputHasFocus(true)
+          }
 
-            const inputFocus = (e: Event) => {
-              if (e && e.target) {
-                const input = e.target as HTMLInputElement
-                input.select()
-              }
-              setInputHasFocus(true)
-            }
+          // when the input loses focus, we need to wait a moment before hiding the menu
+          // in case the blur was caused by clicking on a menu item
+          const inputBlur = (e: Event) => setTimeout(() => setInputHasFocus(false), 100)
 
-            // when the input loses focus, we need to wait a moment before hiding the menu
-            // in case the blur was caused by clicking on a menu item
-            const inputBlur = (e: Event) => setTimeout(() => setInputHasFocus(false), 100)
-
-            const keyDown = (event: KeyboardEvent) => {
-              if (event) {
-                switch (event.which) {
-                  case codes['enter']:
-                  case codes['tab']:
-                    load(values.documentId)
-                }
+          const keyDown = (event: KeyboardEvent) => {
+            if (event) {
+              switch (event.which) {
+                case codes['enter']:
+                case codes['tab']:
+                  load(values.documentId)
               }
             }
-            return (
-              <React.Fragment>
-                <div css={styles.toolbarGroup}>
-                  <div css={styles.menuWrapper}>
-                    <Field
-                      type="text"
-                      name="documentId"
-                      css={styles.input}
-                      onFocus={inputFocus}
-                      onBlur={inputBlur}
-                      onKeyDown={keyDown}
-                    />
-                    <div css={menu(inputHasFocus)}>
-                      {cevitxe.knownDocumentIds.map(documentId => (
-                        <a
-                          key={documentId}
-                          role="button"
-                          type="button"
-                          href={url(documentId)}
-                          css={styles.menuItem}
-                        >
-                          {documentId}
-                        </a>
-                      ))}
-                    </div>
-                  </div>
-                  <div>
-                    <a
-                      role="button"
-                      type="button"
-                      href={url(values.documentId)}
-                      css={styles.button}
-                    >
-                      Join
-                    </a>
+          }
+          return (
+            <React.Fragment>
+              <div css={styles.toolbarGroup}>
+                <div css={styles.menuWrapper}>
+                  <Field
+                    type="text"
+                    name="documentId"
+                    css={styles.input}
+                    onFocus={inputFocus}
+                    onBlur={inputBlur}
+                    onKeyDown={keyDown}
+                  />
+                  <div css={menu(inputHasFocus)}>
+                    {cevitxe.knownDocumentIds.map(documentId => (
+                      <a
+                        key={documentId}
+                        role="button"
+                        type="button"
+                        href={url(documentId)}
+                        css={styles.menuItem}
+                      >
+                        {documentId}
+                      </a>
+                    ))}
                   </div>
                 </div>
-                <div css={styles.toolbarGroup}>
-                  <button role="button" type="button" onClick={newClick} css={styles.button}>
-                    New
-                  </button>
+                <div>
+                  <a role="button" type="button" href={url(values.documentId)} css={styles.button}>
+                    Join
+                  </a>
                 </div>
-                <div css={styles.toolbarGroup}>
-                  <label>{busy ? 'busy' : 'idle'}</label>
-                </div>
-                <div css={styles.toolbarGroup}>
-                  <label>{cevitxe.connectionCount}</label>
-                </div>
-              </React.Fragment>
-            )
-          }}
-        </Formik>
-      )}
+              </div>
+              <div css={styles.toolbarGroup}>
+                <button role="button" type="button" onClick={newClick} css={styles.button}>
+                  New
+                </button>
+              </div>
+              <div css={styles.toolbarGroup}>
+                <label>{busy ? 'busy' : 'idle'}</label>
+              </div>
+              <div css={styles.toolbarGroup}>
+                <label>{cevitxe.connectionCount}</label>
+              </div>
+            </React.Fragment>
+          )
+        }}
+      </Formik>
     </div>
   )
 }


### PR DESCRIPTION
Potentially fixes #19

I believe that we still must await the loading of items from storage before the cevitxe store can truly be created. This leads me to believe that it's not a cevitxe async issue but rather a UI pattern we need to work out.

This PR allows the cevitxe Toolbar to always be rendered instead of being hidden until `appStore` is available. I've also updated the grid example to show the `Loading` component until the store is ready.

Note: I also added a `key` property to the `DataGenerator` options to solve a minor React error.

#### Next steps
- Potentially disable `Toolbar` elements until the store is ready?
I'm not sure if we want to allow or discourage creating/joining stores while a store is currently being loaded.