### PR TITLE
Less chatty sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "projects": [
       "<rootDir>/packages/core",
       "<rootDir>/packages/signal-client",
-      "<rootDir>/packages/signal-server"
+      "<rootDir>/packages/signal-server",
+      "<rootDir>/packages/examples/grid"
     ]
   }
 }

--- a/packages/core/src/Connection.test.ts
+++ b/packages/core/src/Connection.test.ts
@@ -45,7 +45,7 @@ describe('Connection', () => {
     let key: keyof FooStateDoc
     for (key in initialState) {
       const value = initialState[key]
-      repo.set(key, A.from(value, localActorId))
+      await repo.set(key, A.from(value, localActorId))
     }
   })
 

--- a/packages/core/src/Connection.ts
+++ b/packages/core/src/Connection.ts
@@ -16,15 +16,15 @@ const log = debug('cevitxe:connection')
 export class Connection extends EventEmitter {
   private repoSync: RepoSync
   private peerSocket: WebSocket | null
-  private dispatch?: Dispatch<AnyAction>
+  private dispatch: Dispatch<AnyAction>
   private repo: Repo<any>
 
-  constructor(repo: Repo<any>, peerSocket: WebSocket, dispatch?: Dispatch<AnyAction>) {
+  constructor(repo: Repo<any>, peerSocket: WebSocket, dispatch: Dispatch<AnyAction>) {
     super()
     log('new connection')
     this.repo = repo
     this.peerSocket = peerSocket
-    if (dispatch) this.dispatch = dispatch
+    this.dispatch = dispatch
 
     this.peerSocket.onmessage = this.receive.bind(this)
 
@@ -37,15 +37,13 @@ export class Connection extends EventEmitter {
     log('receive %o', message)
     this.emit('receive', message)
     await this.repoSync.receive(message) // this updates the doc
-    if (this.dispatch) {
-      // dispatch the changes from the peer
-      this.dispatch({
-        type: RECEIVE_MESSAGE_FROM_PEER,
-        payload: {
-          message,
-        },
-      })
-    }
+    // dispatch the changes from the peer
+    this.dispatch({
+      type: RECEIVE_MESSAGE_FROM_PEER,
+      payload: {
+        message,
+      },
+    })
   }
 
   send = (message: Message) => {

--- a/packages/core/src/Connection.ts
+++ b/packages/core/src/Connection.ts
@@ -37,17 +37,14 @@ export class Connection extends EventEmitter {
     log('receive %o', message)
     this.emit('receive', message)
     await this.repoSync.receive(message) // this updates the doc
-    if (message.changes) {
-      log('%s changes received', message.changes.length)
-      if (this.dispatch) {
-        // dispatch the changes from the peer for middleware to write them to local feed
-        this.dispatch({
-          type: RECEIVE_MESSAGE_FROM_PEER,
-          payload: {
-            message,
-          },
-        })
-      }
+    if (this.dispatch) {
+      // dispatch the changes from the peer
+      this.dispatch({
+        type: RECEIVE_MESSAGE_FROM_PEER,
+        payload: {
+          message,
+        },
+      })
     }
   }
 

--- a/packages/core/src/Message.ts
+++ b/packages/core/src/Message.ts
@@ -16,20 +16,22 @@ export interface HelloMessage {
 /**
  * Request a document we don't have (snapshot and changes)
  */
-export const REQUEST_DOC = 'REQUEST_DOC'
-export interface RequestDocMessage {
-  type: typeof REQUEST_DOC
-  documentId: string
+export const REQUEST_DOCS = 'REQUEST_DOCS'
+export interface RequestDocsMessage {
+  type: typeof REQUEST_DOCS
+  documentIds: string[]
 }
 
 /**
  * Advertise new document
  */
-export const ADVERTISE_DOC = 'ADVERTISE_DOC'
-export interface AdvertiseDocMessage {
-  type: typeof ADVERTISE_DOC
-  documentId: string
-  clock: Clock
+export const ADVERTISE_DOCS = 'ADVERTISE_DOCS'
+export interface AdvertiseDocsMessage {
+  type: typeof ADVERTISE_DOCS
+  documents: {
+    documentId: string
+    clock: Clock
+  }[]
 }
 
 /**
@@ -63,11 +65,13 @@ interface SendAllHistoryMessage {
 /**
  * Send snapshot for a document
  */
-export const SEND_SNAPSHOT = 'SEND_SNAPSHOT'
-interface SendSnapshotMessage {
-  type: typeof SEND_SNAPSHOT
-  documentId: string
-  snapshot: any
+export const SEND_SNAPSHOTS = 'SEND_SNAPSHOTS'
+interface SendSnapshotsMessage {
+  type: typeof SEND_SNAPSHOTS
+  snapshots: {
+    documentId: string
+    snapshot: any
+  }[]
 }
 
 /**
@@ -81,10 +85,10 @@ interface SendAllSnapshotsMessage {
 
 export type Message =
   | HelloMessage
-  | RequestDocMessage
-  | AdvertiseDocMessage
+  | RequestDocsMessage
+  | AdvertiseDocsMessage
   | SendChangesMessage
   | RequestAllMessage
   | SendAllHistoryMessage
-  | SendSnapshotMessage
+  | SendSnapshotsMessage
   | SendAllSnapshotsMessage

--- a/packages/core/src/Message.ts
+++ b/packages/core/src/Message.ts
@@ -5,6 +5,15 @@ import { RepoSnapshot, RepoHistory } from './types'
 type Clock = Map<string, number>
 
 /**
+ * Kick off our interaction with a peer by telling them how many documents we have
+ */
+export const HELLO = 'HELLO'
+export interface HelloMessage {
+  type: typeof HELLO
+  documentCount: number
+}
+
+/**
  * Request a document we don't have (snapshot and changes)
  */
 export const REQUEST_DOC = 'REQUEST_DOC'
@@ -71,6 +80,7 @@ interface SendAllSnapshotsMessage {
 }
 
 export type Message =
+  | HelloMessage
   | RequestDocMessage
   | AdvertiseDocMessage
   | SendChangesMessage

--- a/packages/core/src/Repo.ts
+++ b/packages/core/src/Repo.ts
@@ -168,7 +168,8 @@ export class Repo<T = any> extends EventEmitter {
    * @returns true if this repo has this document (even if it's been deleted)
    */
   has(documentId: string): boolean {
-    return this.state.hasOwnProperty(documentId) //
+    // if the document has been deleted, its snapshot set to `null`, but the map still contains the entry
+    return this.state.hasOwnProperty(documentId)
   }
 
   /**
@@ -311,7 +312,8 @@ export class Repo<T = any> extends EventEmitter {
   }
 
   /**
-   * Removes the snapshot with the given `documentId` from in-memory state.
+   * Removes the snapshot with the given `documentId` from in-memory state. (More precisely, sets it
+   * to `null` as a marker that we've seen the document before.)
    * @param documentId
    */
   removeSnapshot(documentId: string) {

--- a/packages/core/src/Repo.ts
+++ b/packages/core/src/Repo.ts
@@ -391,11 +391,7 @@ export class Repo<T = any> extends EventEmitter {
   private async loadSnapshotsFromDb() {
     const snapshots = await this.database!.getAll('snapshots')
     for (const { documentId, snapshot } of snapshots) {
-      if (snapshot === null || snapshot[DELETED]) {
-        // omit deleted documents
-      } else {
-        this.state[documentId] = snapshot
-      }
+      this.state[documentId] = snapshot[DELETED] ? null : snapshot
     }
   }
 

--- a/packages/core/src/Repo.ts
+++ b/packages/core/src/Repo.ts
@@ -1,4 +1,4 @@
-﻿import { RepoHistory } from './types'
+import { RepoHistory } from './types'
 import A from 'automerge'
 import { newid } from 'cevitxe-signal-client'
 import debug from 'debug'
@@ -162,6 +162,13 @@ export class Repo<T = any> extends EventEmitter {
    */
   get documentIds() {
     return Object.keys(this.state)
+  }
+
+  /**
+   * @returns true if this repo has this document (even if it's been deleted)
+   */
+  has(documentId: string): boolean {
+    return this.state.hasOwnProperty(documentId) //
   }
 
   /**

--- a/packages/core/src/Repo.ts
+++ b/packages/core/src/Repo.ts
@@ -1,4 +1,4 @@
-import { RepoHistory } from './types'
+﻿import { RepoHistory } from './types'
 import A from 'automerge'
 import { newid } from 'cevitxe-signal-client'
 import debug from 'debug'
@@ -177,16 +177,10 @@ export class Repo<T = any> extends EventEmitter {
    * @param documentId
    */
   async get(documentId: string): Promise<A.Doc<T>> {
+    // TODO: reimplement caching
     this.log('get', documentId)
-    // if (!this.docCache.has(documentId)) {
     const doc = await this.reconstructDoc(documentId)
     return doc
-    // await this.saveSnapshot(documentId, doc)
-    // this.docCache.set(documentId, doc)
-    // } else {
-    // }
-    // const cachedDoc = this.docCache.get(documentId)
-    // return cachedDoc
   }
 
   /**

--- a/packages/core/src/Repo.ts
+++ b/packages/core/src/Repo.ts
@@ -364,7 +364,7 @@ export class Repo<T = any> extends EventEmitter {
   async loadHistory(history: RepoHistory) {
     for (const documentId in history) {
       const changes = history[documentId]
-      await this.appendChangeset({ documentId, changes })
+      await this.applyChanges(documentId, changes)
     }
   }
 

--- a/packages/core/src/Repo.ts
+++ b/packages/core/src/Repo.ts
@@ -131,7 +131,7 @@ export class Repo<T = any> extends EventEmitter {
       await this.createFromSnapshot({})
     } else {
       this.log('recovering an existing repo from persisted state')
-      await this.rebuildSnapshotsFromHistory()
+      await this.loadSnapshotsFromDb()
     }
     this.emit('ready')
     return this.state
@@ -362,7 +362,6 @@ export class Repo<T = any> extends EventEmitter {
    * Used when receiving the entire current state of a repo from a peer.
    */
   async loadHistory(history: RepoHistory) {
-    // TODO: clear current changes?
     for (const documentId in history) {
       const changes = history[documentId]
       await this.appendChangeset({ documentId, changes })
@@ -389,7 +388,7 @@ export class Repo<T = any> extends EventEmitter {
   /**
    * Loads all the repo's snapshots into memory
    */
-  private async rebuildSnapshotsFromHistory() {
+  private async loadSnapshotsFromDb() {
     const snapshots = await this.database!.getAll('snapshots')
     for (const { documentId, snapshot } of snapshots) {
       if (snapshot === null || snapshot[DELETED]) {

--- a/packages/core/src/Repo.ts
+++ b/packages/core/src/Repo.ts
@@ -173,6 +173,13 @@ export class Repo<T = any> extends EventEmitter {
   }
 
   /**
+   * Returns the number of document IDs that this repo has (including deleted)
+   */
+  get count() {
+    return this.documentIds.length
+  }
+
+  /**
    * Reconstitutes an Automerge document from its change history
    * @param documentId
    */

--- a/packages/core/src/Repo.ts
+++ b/packages/core/src/Repo.ts
@@ -49,11 +49,15 @@ export class Repo<T = any> extends EventEmitter {
    */
   public databaseName: string
 
+  /**
+   * Unique identifier representing this peer
+   */
   public clientId: string
+
   /**
    * In-memory map of document snapshots.
    */
-  private state: RepoSnapshot<T>
+  private state: RepoSnapshot<T> = {}
 
   private docCache: Cache<string, any>
 
@@ -69,7 +73,6 @@ export class Repo<T = any> extends EventEmitter {
     this.discoveryKey = discoveryKey
     this.databaseName = databaseName
     this.log = debug(`cevitxe:repo:${databaseName}`)
-    this.state = {}
     this.handlers = new Set()
     this.docCache = new Cache({ max: 1000 })
     this.clientId = clientId

--- a/packages/core/src/RepoSync.test.ts
+++ b/packages/core/src/RepoSync.test.ts
@@ -153,7 +153,9 @@ describe(`RepoSync`, () => {
       const { localRepo, remoteRepo } = await setup()
 
       await localRepo.set(documentId, A.from({ wrens: 2, swallows: 1, vultures: 234 }, 'L'))
+      await _yield()
       await remoteRepo.set(documentId, A.from({ ['andean condors']: 34 }, 'R'))
+      await _yield()
 
       await makeConnections(localRepo, remoteRepo)
 

--- a/packages/core/src/RepoSync.ts
+++ b/packages/core/src/RepoSync.ts
@@ -113,8 +113,8 @@ export class RepoSync {
     switch (msg.type) {
       case HELLO: {
         // they are introducing themselves by saying how many documents they have
-        const theirCount = msg.documentCount
-        const ourCount = this.repo.count
+        const theirCount: number = +msg.documentCount
+        const ourCount: number = +this.repo.count
         this.log('received hello ', { theirCount, ourCount })
         if (theirCount === 0 && ourCount === 0) {
           // neither of us has anything, nothing to talk about until we get documents

--- a/packages/core/src/RepoSync.ts
+++ b/packages/core/src/RepoSync.ts
@@ -271,11 +271,12 @@ export class RepoSync {
    */
   private async maybeRequestChanges(
     documentId: string,
-    theirClock: Clock = this.getOurClock(documentId)
+    theirClock: Clock | Promise<Clock> = this.getClockFromDoc(documentId)
   ) {
     this.log('maybeRequestChanges', documentId)
     const ourClock = this.getOurClock(documentId)
-    if (isMoreRecent(theirClock, ourClock)) await this.advertise(documentId, theirClock)
+    theirClock = await theirClock
+    if (isMoreRecent(theirClock, ourClock)) this.advertise(documentId, theirClock)
   }
 
   /**

--- a/packages/core/src/RepoSync.ts
+++ b/packages/core/src/RepoSync.ts
@@ -1,4 +1,4 @@
-﻿import A from 'automerge'
+import A from 'automerge'
 import debug from 'debug'
 import { Map } from 'immutable'
 import { Repo } from './Repo'
@@ -240,7 +240,9 @@ export class RepoSync {
    * Sends a hello message including our document count
    */
   private async sendHello() {
-    this.send({ type: HELLO, documentCount: this.repo.count })
+    const documentCount = this.repo.count
+    this.log('sending hello', documentCount)
+    this.send({ type: HELLO, documentCount })
   }
 
   /**

--- a/packages/core/src/RepoSync.ts
+++ b/packages/core/src/RepoSync.ts
@@ -100,8 +100,23 @@ export class RepoSync {
     this.log('receive', msg)
     switch (msg.type) {
       case HELLO: {
-        const { documentCount } = msg
-
+        // they are introducing themselves by saying how many documents they have
+        const theirCount = msg.documentCount
+        const ourCount = this.repo.count
+        this.log('received hello ', { theirCount, ourCount })
+        if (theirCount === 0 && ourCount === 0) {
+          // neither of us has anything, nothing to talk about until we get documents
+          this.log('nothing to do')
+        } else if (theirCount === 0 && ourCount > 0) {
+          // we have documents and they have none, so let's send them everything we have
+          this.log('sending everything')
+          this.sendAllSnapshots()
+          this.sendAllHistory()
+        } else {
+          // we both have some documents, so we'll each advertise everything we have
+          this.log('advertising everything')
+          // TODO
+        }
         break
       }
       case SEND_CHANGES: {

--- a/packages/core/src/RepoSync.ts
+++ b/packages/core/src/RepoSync.ts
@@ -271,7 +271,7 @@ export class RepoSync {
    */
   private async maybeRequestChanges(
     documentId: string,
-    theirClock: Clock | Promise<Clock> = this.getClockFromDoc(documentId)
+    theirClock: Clock = this.getOurClock(documentId)
   ) {
     this.log('maybeRequestChanges', documentId)
     const ourClock = this.getOurClock(documentId)
@@ -303,7 +303,7 @@ export class RepoSync {
     this.send({
       type: SEND_CHANGES,
       documentId,
-      clock: clock.toJS() as any,
+      clock: clock.toJS() as Clock,
       changes,
     })
     this.updateClock(documentId, ours)
@@ -316,12 +316,9 @@ export class RepoSync {
    * @param documentId
    * @param [_clock]
    */
-  private async advertise(
-    documentId: string,
-    _clock: Clock | Promise<Clock> = this.getClockFromDoc(documentId)
-  ) {
+  private async advertise(documentId: string, _clock: Clock = this.getOurClock(documentId)) {
     this.log('advertise', documentId)
-    const clock = (await _clock).toJS() as Clock
+    const clock = _clock.toJS() as Clock
     this.send({ type: ADVERTISE_DOCS, documents: [{ documentId, clock }] })
   }
 

--- a/packages/core/src/RepoSync.ts
+++ b/packages/core/src/RepoSync.ts
@@ -1,4 +1,4 @@
-﻿import A from 'automerge'
+import A from 'automerge'
 import debug from 'debug'
 import { Map } from 'immutable'
 import { Repo } from './Repo'
@@ -129,7 +129,7 @@ export class RepoSync {
         break
       }
       case ADVERTISE_DOCS: {
-        // they are letting us know they have this specific version of this doc
+        // they are letting us know they have this specific version of each of these docs
         const { documents } = msg
         for (const { documentId, clock } of documents) {
           this.updateClock(documentId, theirs, clock)
@@ -285,9 +285,9 @@ export class RepoSync {
   }
 
   /**
-   * Informs our peer that we a specific version of a document, so they can see if they have an older
-   * version (in which case they will request changes) or a newer version (in which case they will
-   * send changes)
+   * Informs our peer that we have a specific version of a document, so they can see if they have an
+   * older version (in which case they will request changes) or a newer version (in which case they
+   * will send changes)
    * @param documentId
    * @param [_clock]
    */

--- a/packages/core/src/RepoSync.ts
+++ b/packages/core/src/RepoSync.ts
@@ -1,4 +1,4 @@
-﻿import A from 'automerge'
+import A from 'automerge'
 import debug from 'debug'
 import { Map } from 'immutable'
 import { Repo } from './Repo'
@@ -112,7 +112,7 @@ export class RepoSync {
         this.updateClock(documentId, theirs, clock)
         // we have the document as well; see if we have a more recent version than they do; if so
         // send them the changes they're missing
-        if (this.weHaveDoc(documentId)) await this.maybeSendChanges(documentId)
+        if (this.has(documentId)) await this.maybeSendChanges(documentId)
         // we don't have this document at all; ask for it
         else this.requestDoc(documentId)
         break
@@ -158,10 +158,11 @@ export class RepoSync {
 
   /**
    * @param documentId
-   * @returns  Returns true if the current repo has a snapshot for the requested documentId
+   * @returns  Returns true if the current repo has ever seen the requested documentId (even if it's
+   * been deleted)
    */
-  private weHaveDoc(documentId: string) {
-    return this.repo.getSnapshot(documentId) !== undefined
+  private has(documentId: string) {
+    return this.repo.has(documentId)
   }
 
   /**
@@ -364,7 +365,7 @@ export class RepoSync {
    * @param documentId
    * @returns clock from doc
    */
-  private async getClockFromDoc(documentId: string): Promise<Clock> {
+    if (!this.has(documentId)) return EMPTY_CLOCK
     if (!this.weHaveDoc(documentId)) return EMPTY_CLOCK
     const state = (await this.getBackendState(documentId)) as any
     return state.getIn(['opSet', 'clock'])

--- a/packages/core/src/RepoSync.ts
+++ b/packages/core/src/RepoSync.ts
@@ -12,7 +12,6 @@ import {
   SEND_ALL_HISTORY,
   SEND_ALL_SNAPSHOTS,
   HELLO,
-  AdvertiseDocsMessage,
 } from './Message'
 import { RepoHistory, RepoSnapshot } from './types'
 

--- a/packages/core/src/RepoSync.ts
+++ b/packages/core/src/RepoSync.ts
@@ -1,4 +1,4 @@
-﻿import A from 'automerge'
+import A from 'automerge'
 import debug from 'debug'
 import { Map } from 'immutable'
 import { Repo } from './Repo'
@@ -20,6 +20,22 @@ type ClockMap = Map<string, Clock>
 
 const EMPTY_CLOCK: Clock = Map()
 const EMPTY_CLOCKMAP: ClockMap = Map()
+
+// TODO: Submit these to Automerge
+const _A = {
+  ...A,
+
+  getMissingChanges: (ourDoc: A.Doc<any>, theirClock: A.Clock): A.Change[] => {
+    if (theirClock === undefined) return []
+    const ourState = A.Frontend.getBackendState(ourDoc)
+    return A.Backend.getMissingChanges(ourState!, theirClock)
+  },
+
+  getClock: (doc: A.Doc<any>): Clock => {
+    const state = A.Frontend.getBackendState(doc) as any // BackendState doesn't have a public API
+    return state.getIn(['opSet', 'clock']) as Clock
+  },
+}
 
 /**
  * One instance of `RepoSync` keeps one local document in sync with one remote peer's replica of the

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -154,15 +154,24 @@ export function collection<T = any>(name: string, { idField = 'id' }: Collection
   }
 
   /**
-   * Marks all items in the collection as deleted. ("PRIVATE")
+   * Marks all items in the collection as deleted.
    * @param repo
    */
   const markAllDeleted = async (repo: Repo<any>) => {
     for (const documentId of repo.documentIds) {
       if (isCollectionKey(documentId)) {
-        // update snapshot
         repo.change(documentId, setDeleteFlag)
-        // update underlying data (fire & forget)
+      }
+    }
+  }
+
+  /**
+   * Removes all items in the collection from the snapshot.
+   * @param repo
+   */
+  const removeAllFromSnapshot = (repo: Repo<any>) => {
+    for (const documentId of repo.documentIds) {
+      if (isCollectionKey(documentId)) {
         repo.removeSnapshot(documentId)
       }
     }
@@ -210,6 +219,7 @@ export function collection<T = any>(name: string, { idField = 'id' }: Collection
       count,
     },
     markAllDeleted,
+    removeAllFromSnapshot,
   }
 }
 

--- a/packages/core/src/lib/lessOrEqual.ts
+++ b/packages/core/src/lib/lessOrEqual.ts
@@ -1,6 +1,8 @@
 ﻿import { Map } from 'immutable'
 type Clock = Map<string, number>
 
+export const isMoreRecent = (clock1: Clock, clock2: Clock) => !lessOrEqual(clock1, clock2)
+
 export const lessOrEqual = (clock1: Clock, clock2: Clock) => {
   // coerce to plain JS
   clock1 = clock1.toJS ? (clock1.toJS() as Clock) : clock1

--- a/packages/core/src/lib/lessOrEqual.ts
+++ b/packages/core/src/lib/lessOrEqual.ts
@@ -2,11 +2,19 @@
 type Clock = Map<string, number>
 
 export const lessOrEqual = (clock1: Clock, clock2: Clock) => {
-  const clockIsLessOrEqual = (key: string) => clock1.get(key, 0) <= clock2.get(key, 0)
-  const clockSeq1 = clock1.keySeq().toJS() as string[]
-  const clockSeq2 = clock2.keySeq().toJS() as string[]
-  const both = clockSeq1.concat(clockSeq2)
-  return both.map(clockIsLessOrEqual).reduce(allTrue, true)
+  // coerce to plain JS
+  clock1 = clock1.toJS ? (clock1.toJS() as Clock) : clock1
+  clock2 = clock2.toJS ? (clock2.toJS() as Clock) : clock1
+
+  // get a list of all the keys
+  const actors1 = Object.keys(clock1)
+  const actors2 = Object.keys(clock2)
+
+  const allActors = actors1.concat(actors2) // not worth the effort of deduplicating
+
+  // @ts-ignore
+  const clockIsLessOrEqual = (key: string) => (clock1[key] || 0) <= (clock2[key] || 0)
+  return allActors.map(clockIsLessOrEqual).reduce(allTrue, true)
 }
 
 const allTrue = (acc: boolean, d: boolean): boolean => acc && d

--- a/packages/examples/grid/public/index.html
+++ b/packages/examples/grid/public/index.html
@@ -5,20 +5,6 @@
     <link rel="shortcut icon" href="%PUBLIC_URL%/icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
     <title>Cevitxe Grid Sample</title>
   </head>
   <body>

--- a/packages/examples/grid/src/components/DataGenerator.tsx
+++ b/packages/examples/grid/src/components/DataGenerator.tsx
@@ -57,7 +57,7 @@ export function DataGenerator() {
           {progress ? 'Generating...' : 'Generate data'}
         </button>
         <div css={menu(menuOpen)}>
-          {[10, 100, 1000, 10000, 20000, 50000, 100000].map(rows => (
+          {[10, 100, 1000, 10000, 100000, 200000, 500000, 1000000].map(rows => (
             <button
               key={rows}
               css={styles.menuItem}
@@ -67,7 +67,7 @@ export function DataGenerator() {
                 generate(rows)
               }}
             >
-              {rows} rows
+              {rows.toLocaleString()} rows
             </button>
           ))}
         </div>

--- a/packages/examples/grid/src/components/Toolbar.tsx
+++ b/packages/examples/grid/src/components/Toolbar.tsx
@@ -3,7 +3,6 @@ import { jsx } from '@emotion/core'
 import { collection } from 'cevitxe'
 import { styles } from 'cevitxe-toolbar'
 import { useSelector } from 'react-redux'
-import { Counter, CounterProgress } from './Counter'
 import { DataGenerator } from './DataGenerator'
 
 export const Toolbar = () => (
@@ -11,8 +10,8 @@ export const Toolbar = () => (
     <DataGenerator />
     <Loading />
     <Rows />
-    <Counter />
-    <CounterProgress />
+    {/* <Counter />
+    <CounterProgress /> */}
   </div>
 )
 


### PR DESCRIPTION
We need a better protocol for the initial interactions in `RepoSync`. Right now each side just
starts advertising each document they have, one at a time, which means the other side then needs to
process that advertisement. This is fine when the two peers are mostly synced up, but it makes for a
slow initial sync and is really inefficient with large numbers of records.

Instead I'm thinking we should do this:

- Each peer starts by saying 'Hello I have N documents'.
- If both peers have **zero** documents, there's nothing to talk about.
- If one peer has **zero** documents and the other has **some**, the one that has some just sends  them all.
- If both peers have **some** documents, they both send an **index** file listing the ids and clocks they have for the entire repo.
- On receiving this message, each side figures out where they have more recent information and sends changes in a single batch.
