### PR TITLE
Authentication & authorization

### DIFF
--- a/authorization-pr.md
+++ b/authorization-pr.md
@@ -1,0 +1,270 @@
+﻿This is a placeholder PR to propose one approach to meeting the authentication & authorization requirements specified in #37.
+
+## Overview
+
+**Authentication** is required by the signal server, and provided by a lightweight authentication server, which in turn relies on external OAuth providers.
+
+**Authorization** information about roles, permissions, and authorized users is encoded in a special JSON document that is included in the repo under a reserved key. This document is included with the repository, digitally signed, and replicated in plaintext to all actors.
+
+Permissions can be set both at the **document** level (e.g. some actors can't see agent records) and at the **field** level (e.g. some actors can't read salary data).
+
+- Sensitive **documents** are simply never shared with unauthorized actors.
+
+- Sensitive **fields** are encrypted using a key that is only available to authorized actors. The encrypted data is otherwise treated the same as any other data, and replicated to all actors.
+
+All actors' changes are **digitally signed** to prove they come from that actor. Unauthorized changes by actors with read-only access to certain documents or fields are simply ignored by other actors.
+
+## Authentication
+
+`cevitxe-signal-server` will now require an identity verified by a new authentication microservice, `cevitxe-auth-server`. This is a very minimal service that does just two things:
+
+1. interface with one or more external OAuth providers (e.g. Google, GitHub, or an organization's SSO)
+2. interface with an external key management service
+
+Step by step:
+
+1. Alice tells the signal server that she has repository `raw-fish`, and that she is willing to connect with anyone who can prove they are Bob.
+2. Bob connects to the signal server and says he is interested in `raw-fish`.
+3. The signal server sends Bob to the auth server, which tells Bob to go to Google and come back with a token proving his identity.
+4. Bob provides his credentials (password + 2FA) to Google's satisfaction.
+5. Google sends Bob back to the auth server along with a JWT that can only be decrypted with a private key known to the auth server.
+6. The auth server sends Bob back to the signal server along with a new JWT that includes the role-specific encryption keys he will need.
+7. The signal server is now satisfied that Bob is who he says he is, and can vouch for him to Alice (and anyone else, as long as Bob's token hasn't expired)
+
+## Authorization
+
+### Encryption keys
+
+This system relies on three types of keypairs:
+
+1. **Root**: A single admin-only keypair, used to sign the access control document
+2. **Role**: One per role, used to decrypt sensitive field-level data
+3. **Actor**: One per actor, used to sign changes
+
+These keys are generated and stored by the auth server, and provided to actors when they successfully authenticate.
+
+#### Encrypting for readers with different keys
+
+The encrypted salary data needs to be independently decrypted by users with different roles. To accomplish this, we:
+
+1. randomly generate a symmetric key `K` that we'll use for the salary field;
+2. for each role that can read salaries, use the role's public key to make an encrypted copy of `K`;
+3. in the access control document, include a dictionary mapping roles to the corresponding symmetric key.
+
+Now to decrypt salary data, an actor first finds and decrypts the key corresponding to their role; then uses that key to decrypt the data itself.
+
+### Enforcing `read` permissions
+
+In our example scenario, Dan isn't allowed to see agents (document-level permissions) or salaries (field-level permissions).
+
+When Alice synchronizes with Dan, she has two ways to hide information from him:
+
+1.  **Omission:** Alice can choose to share some documents but not others. This is how we enforce
+    **document-level permissions**: Alice can share nothing but civilian records with Dan, and
+    that's all he'll ever see.
+
+2.  **Encryption:** Alice can encrypt the contents of individual fields. This is how we enforce
+    **field-level permissions**: Alice can encrypt the contents of the salary field using a key that
+    Dan doesn't have, but that authorized readers (Carol, Frank, and Gloria) do.
+
+In a client/server setup, read permissions are typically enforced by omission; so that's the model we're familiar with.
+
+In our distributed network, this works for document-level permissions. But Automerge does its magic by keeping the history of an entire document in sync. So any sensitive information _within_ a document needs to be passed around in encrypted form, such that everyone can see it's there, resolve conflicting versions, and so on; but only authorized readers can decrypt it.
+
+### Enforcing `write` permissions
+
+In a client/server model, enforcing write permissions is straightforward, since a central server can simply reject changes coming from unauthorized clients.
+
+In this distributed model, changes might be passed from one actor to another several times before we receive them. Suppose Alice receives Bob's changes via Carol. She needs to be confident that Carol hasn't modified those changes before passing them on. In fact, she needs to be confident that Carol isn't making her own changes and claiming they're Bob's!
+
+To properly enforce `write` permissions, each actor needs to digitally sign their own changes. Step by step:
+
+1. Bob changes Aldrich Ames' salary.
+2. Bob signs the change using his private key.
+3. Bob goes online; Carol happens to be online as well.
+4. Carol and Bob sync up; Carol receives Bob's change.
+5. Carol looks up Bob's public key in the access control document and uses it to verify the signed
+   change; it checks out.
+6. Carol also checks the access control document to verify that Bob has write permissions for the
+   salary field; he does.
+7. Satisfied, Carol adds the change to her append-only log, and updates her snapshot of Aldrich's
+   record.
+8. Bob goes offline.
+9. Alice comes online and connects to Carol.
+10. Alice and Carol sync up; Alice receives Bob's change from Carol.
+11. Alice verifies the signature to be sure Bob made the change, and confirms that Bob had
+    permission to make the change. She updates her own records as well.
+
+If at any point one of these checks fails - say Carol was trying to pass off her changes as Bob's, or Bob didn't have the right permissions - the receiving actor can simply ignore the change.
+
+> In either situation, it may make sense to also raise some sort of alarm ("Bob is misbehaving", or "Carol is trying to impersonate Bob") that would be handled at the application level.
+
+### Enforcing admin permissions
+
+Only admins can edit the authorization rules for a repository. This is enforced by treating the access control document as read-only for anyone not in an `admin` role: Changes by unauthorized actors will be rejected by other actors.
+
+## Revoking or downgrading permissions
+
+> **A note about reality:** Alice has disclosed information to Bob, she can't exactly _un_-disclose it. Also, unless she has complete control over Bob's computing environment, she can't really prevent Bob from copying and/or distributing the information: He could make a backup onto a thumb drive or a cloud server, or he could send a copy to the New York Times or to the Russians, etc.
+> The most any system can promise with regard to information an actor should no longer see is:
+>
+> - try to erase the information that we've cached or persisted on their devices
+> - keep them from receiving any new information in the future
+
+Revoking **write permissions** at any level, and **read permissions** at the **document level**, is a matter of applying the new rules going forward (and in the case of read permissions, removing the newly disallowed documents are removed from the storage we control on the actor's device).
+
+The tricky part is revoking **read permissions** at the **field level**, because of the way we [encrypt for readers with different keys](#encrypting-for-readers-with-different-keys).
+
+As an example, let's suppose Gloria is demoted from from `civilian-manager` to `civilian`, and as a result she should no longer see salary information.
+
+The first thing we do is to regenerate encryption keys for the `civilian-manager` role, and we re-encrypt the salary key for `civilian-manager`. This way Gloria can no longer access the symmetric key used to encrypt salary data.
+
+For many applications, this is be sufficient. If we're really worried, though, we need regenerate that symmetric key and re-encrypt all the salary data. (Technically Gloria has 'seen' the symmetric key, since she's decrypted it in the past any time she's needed to see salary data.)
+
+## Access control document
+
+We encode the information about [roles and permissions](https:_github.com_DevResults_cevitxe_issues_37#roles) and the list of [authorized actors and their roles](https:__github.com_DevResults_cevitxe_issues_37#actors) in a special JSON document that is included in the repo under a reserved key.
+
+This document is included with the repository, digitally signed with the root key, and replicated in plaintext to all actors.
+
+For example:
+
+```json
+{
+  "CEVITXE_ACCESS-CONTROL": {
+    "roles": {
+      "hr": { "isAdmin": true },
+      "it": { "isAdmin": true },
+      "civilian-hr": {
+        "documentExclusions": { "read": ["agent"] }
+      },
+      "civilian-manager": {
+        "documentExclusions": { "read": ["agent"] },
+        "fieldExclusions": { "write": ["salary"] }
+      },
+      "civilian": {
+        "documentExclusions": { "read": ["agent"] },
+        "fieldExclusions": { "read": ["salary"], "write": ["salary"] }
+      },
+      "auditor": {
+        "fieldExclusions": { "write": "*" }
+      },
+      "connector": {}
+    },
+    "actors": {
+      "Alice": { "role": "hr", "publicKey": "51abN…" },
+      "Bob": { "role": "it", "publicKey": "12KK0…" },
+      "Carol": { "role": "auditor", "publicKey": "4421a…" },
+      "Dan": { "role": "civilian", "publicKey": "AA292…" },
+      "Frank": { "role": "civilian-hr", "publicKey": "29A32…" },
+      "Gloria": { "role": "civilian-manager", "publicKey": "999ZZ…" },
+      "ImNotAServer": { "role": "connector", "publicKey": "39220…" }
+    },
+    "documentExclusions": {
+      "agent": "[?(@.jobTitle!=='Agent')]"
+    },
+    "fieldExclusions": {
+      "salary": {
+        "path": "salary",
+        "keys": {
+          "hr": "g*Lß|º}þbóüA…",
+          "it": "¹6úí*zïóYÜáQÒ…",
+          "civilian-hr": "?26ïtm#êéH)…",
+          "auditor": "JR¢L²ÈÜ<ë3?&^Ù…"
+        }
+      }
+    },
+    "signature": "skdfDSFJD23847…"
+  }
+  // ... repository documents follow
+}
+```
+
+> Note: In the examples, we're referring to actors and roles using readable names like `Alice` and `civilian`. In practice, we can avoid leaking information by using random IDs for both. The human-readable labels can be linked to those IDs in a separate system, or included in the document itself as encrypted metatada.
+>
+> ```js
+> "actors": {
+>   "123abc": {
+>     "name": "$§1k±ÕáÒ", // "Alice", encrypted
+>     "role": "hr",
+>     "publicKey": "51abN…"
+>   },
+>   //...
+> ```
+
+### Schema
+
+An access control document has the following root-level elements:
+
+#### `roles`
+
+Dictionary mapping unique IDs to role definitions. A role definition can have the following elements:
+
+- `isAdmin` (boolean; defaults to `false`) indicates a role with no read or write restrictions, and with the ability to modify the access control document.
+
+  ```js
+    "hr": { "isAdmin": true }
+  ```
+
+  Normally this
+
+- `documentExclusions` and `fieldExclusions` (object; defaults to `{}`) has `read` and `write` properties, each of which is set to an array of keys from the root-level `documentExclusions` and `fieldExclusions`, respectively.
+
+  ```js
+  "civilian": {
+    "documentExclusions": { "read": ["agent"] },
+    "fieldExclusions": { "read": ["salary"], "write": ["salary"] }
+  },
+  ```
+
+#### `actors`
+
+Dictionary mapping unique actor IDs to actor definitions. An actor definition can have the following elements:
+
+- `role` is a reference to a role ID from the `roles` element.
+- `publicKey` is the shared half of a keypair selected by the actor.
+
+<!-- TODO: how/when is the actor's keypair set?  -->
+
+```js
+"actors": {
+  "Alice": { "role": "hr", "publicKey": "51abN…" },
+  "Bob": { "role": "it", "publicKey": "12KK0…" },
+  "Carol": { "role": "auditor", "publicKey": "4421a…" },
+  // ...
+}
+```
+
+#### `documentExclusions`
+
+Dictionary mapping exclusion IDs to [JSONPath](https://www.npmjs.com/package/jsonpath) filter expressions.
+
+```js
+"documentExclusions": {
+  "agent": "[?(@.jobTitle!=='Agent')]"
+},
+```
+
+#### `fieldExclusions`
+
+Dictionary mapping exclusion IDs to field exclusion definitions. A field exclusion definition has two elements:
+
+- `path` is a JSONPath expression identifying the sensitive property. For properties at the root of the document, this will just be the name of the property.
+- `keys` is a dictionary mapping TODO
+
+```js
+"fieldExclusions": {
+  "salary": {
+    "path": "salary",
+    "keys": {
+      "hr": "g*Lß|º}þbóüA…",
+      "it": "¹6úí*zïóYÜáQÒ…",
+      "civilian-hr": "?26ïtm#êéH)…",
+      "auditor": "JR¢L²ÈÜ<ë3?&^Ù…"
+    }
+  }
+```
+
+#### `signature`
+
+The entire access control document is signed with the repository's root private key, and can be verified against the repository's root public key (provided by the signal server when connecting peers).

--- a/authorization-spec.md
+++ b/authorization-spec.md
@@ -1,0 +1,123 @@
+﻿When all data resides on a server, authentication and authorization are well-understood problems with lots of off-the-shelf solutions to choose from. The server acts as a gatekeeper between users and the data: If you don't have the correct credentials, the server just won't let you see data you're not allowed to see, or change it in unauthorized ways.
+
+In a distributed architecture, where data is transmitted from peer to peer and there is no server acting as a central point of access, we'll need a different approach.
+
+The purpose of this issue is to describe the problems of authentication and authorization in the context of Cevitxe's distributed collaboration framework, and specify the criteria that an acceptable solution must meet.
+
+## Scenario
+
+Alice has created a Cevitxe repository: a staff database for an organization that does clandestine work.
+
+#### Sample data
+
+| id     | first    | last      | jobTitle   | salary |
+| ------ | -------- | --------- | ---------- | ------ |
+| 123abc | Aldrich  | Ames      | Agent      | 88000  |
+| 456qrs | Julius   | Rosenberg | Agent      | 77000  |
+| 789stu | Mata     | Hari      | Manager    | 99000  |
+| 777xyz | Jonathan | Pollard   | Mail Clerk | 66000  |
+| 666gwb | Valerie  | Plame     | Agent      | 101000 |
+| 987qed | George   | Smiley    | Agent      | 77000  |
+
+#### Roles
+
+Each actor belongs to one of these roles:
+
+| Role             | Read                     | Write\*          | Admin |
+| ---------------- | ------------------------ | ---------------- | :---: |
+| hr               | all                      | all              |   ✔   |
+| it               | all                      | all              |   ✔   |
+| civilian-hr      | all but agents           | all              |       |
+| civilian-manager | all but agents           | all but salaries |       |
+| civilian         | all but agents, salaries | all              |       |
+| auditor          | all                      | none             |       |
+| connector        | all                      | all              |       |
+
+\*An actor can only write data they can also read; in this column "all" really means "all visible".
+
+#### Actors
+
+| Actor            | Role             | Notes                    |
+| ---------------- | ---------------- | ------------------------ |
+| **Alice**        | hr               | created the repository   |
+| **Bob**          | it               |                          |
+| **Carol**        | auditor          |                          |
+| **Dan**          | civilian         |                          |
+| **Eve**          | (none)           | malicious external actor |
+| **Frank**        | civilian-hr      |                          |
+| **Gloria**       | civilian-manager |                          |
+| **ImNotAServer** | connector        | always-on client         |
+
+## Requirements
+
+### Authentication
+
+1. Authentication can be provided by a third party (e.g. OAuth2 via Google or GitHub).
+2. An unknown actor like Eve should not be able to connect to the other actors at all.
+3. For a new actor to access the dataset for the first time, they have to be online (obv).
+4. Once an actor is authenticated, they can continue to use the same authentication token for N days, at which point it expires and they need to re-authenticate before they can synchronize with another actor.
+
+### Authorization
+
+1. **Administrative permissions:** Only roles marked as `admin` can modify permissions, including designating other roles as `admin`.
+
+2. **Record-level permissions:** Some people work in civilian support roles, some work as secret agents. Agents' identities are very sensitive information: Their records should only be visible to users with the appropriate clearance.
+
+   > For record-level permissions, not even the existence of the record should be divulged to actors that don't have read access to them. (For example, a civilian actor shouldn't even know how many agent records there are.)
+
+3. **Field-level permissions:** Salary information is also sensitive, because the organization has not gone through the difficult but ultimately worthwhile process of salary transparency.
+
+   > For field-level permissions, it's OK for actors without read access to know of the existence of the field. (For example, a non-hr actor can still know that a salary field exists, even if they can't see any of the values.)
+
+4. An actor's permissions must be enforced whether or not they're online.
+
+5. An admin can update permissions for any role at any time, including adding, removing, or modifying any of its specific authorizations. The updated permissions will be replicated to all other peers (immediately or the next time they connect) and will be enforced as soon as they are received.
+
+6. An admin can change an actor's role at any time. That change will be replicated to all other peers (immediately or the next time they connect). The affected actor's new permissions will be enforced as soon as they receive them.
+
+#### Examples
+
+Using the above sample data along with the given roles, here's what some specific actors should see.
+
+- Read-only data looks like _this_
+- Encrypted data looks like ☒☒☒☒☒☒
+
+##### Carol
+
+As an auditor, Carol can see all data but can't edit any of it.
+
+| id       | first      | last        | jobTitle     |    salary |
+| -------- | ---------- | ----------- | ------------ | --------: |
+| _123abc_ | _Aldrich_  | _Ames_      | _Agent_      |  _88,000_ |
+| _456qrs_ | _Julius_   | _Rosenberg_ | _Agent_      |  _77,000_ |
+| _789stu_ | _Mata_     | _Hari_      | _Manager_    |  _99,000_ |
+| _777xyz_ | _Jonathan_ | _Pollard_   | _Mail Clerk_ |  _66,000_ |
+| _666gwb_ | _Valerie_  | _Plame_     | _Agent_      | _101,000_ |
+| _987qed_ | _George_   | _Smiley_    | _Agent_      |  _77,000_ |
+
+##### Dan
+
+As a civilian, Dan can't see anything about agents, and he can't see any salary information.
+
+| id     | first    | last    | jobTitle   | salary |
+| ------ | -------- | ------- | ---------- | -----: |
+| 789stu | Mata     | Hari    | Manager    | ☒☒☒☒☒☒ |
+| 777xyz | Jonathan | Pollard | Mail Clerk | ☒☒☒☒☒☒ |
+
+##### Frank
+
+As civilian HR, Frank can't see agents but can see and edit salary information.
+
+| id     | first    | last    | jobTitle   | salary |
+| ------ | -------- | ------- | ---------- | -----: |
+| 789stu | Mata     | Hari    | Manager    | 99,000 |
+| 777xyz | Jonathan | Pollard | Mail Clerk | 66,000 |
+
+##### Gloria
+
+As a civilian manager, Gloria can't see agents; she can see salaries but not change them.
+
+| id     | first    | last    | jobTitle   | salary   |
+| ------ | -------- | ------- | ---------- | -------- |
+| 789stu | Mata     | Hari    | Manager    | _99,000_ |
+| 777xyz | Jonathan | Pollard | Mail Clerk | _66,000_ |


### PR DESCRIPTION
This is a placeholder PR to propose one approach to meeting the authentication & authorization requirements specified in #37.

## Overview

**Authentication** is required by the signal server, and provided by a lightweight authentication server, which in turn relies on external OAuth providers.

**Authorization** information about roles, permissions, and authorized users is encoded in a special JSON document that is included in the repo under a reserved key. This document is included with the repository, digitally signed, and replicated in plaintext to all actors.

Permissions can be set both at the **document** level (e.g. some actors can't see agent records) and at the **field** level (e.g. some actors can't read salary data).

- Sensitive **documents** are simply never shared with unauthorized actors.

- Sensitive **fields** are encrypted using a key that is only available to authorized actors. The encrypted data is otherwise treated the same as any other data, and replicated to all actors.

All actors' changes are **digitally signed** to prove they come from that actor. Unauthorized changes by actors with read-only access to certain documents or fields are simply ignored by other actors.

## Authentication

`cevitxe-signal-server` will now require an identity verified by a new authentication microservice, `cevitxe-auth-server`. This is a very minimal service that does just two things:

1. interface with one or more external OAuth providers (e.g. Google, GitHub, or an organization's SSO)
2. interface with an external key management service

Step by step:

1. Alice tells the signal server that she has repository `raw-fish`, and that she is willing to connect with anyone who can prove they are Bob.
2. Bob connects to the signal server and says he is interested in `raw-fish`.
3. The signal server sends Bob to the auth server, which tells Bob to go to Google and come back with a token proving his identity.
4. Bob provides his credentials (password + 2FA) to Google's satisfaction.
5. Google sends Bob back to the auth server along with a JWT that can only be decrypted with a private key known to the auth server.
6. The auth server sends Bob back to the signal server along with a new JWT that includes the role-specific encryption keys he will need.
7. The signal server is now satisfied that Bob is who he says he is, and can vouch for him to Alice (and anyone else, as long as Bob's token hasn't expired)

## Authorization

### Encryption keys

This system relies on three types of keypairs:

1. **Root**: A single admin-only keypair, used to sign the access control document
2. **Role**: One per role, used to decrypt sensitive field-level data
3. **Actor**: One per actor, used to sign changes

These keys are generated and stored by the auth server, and provided to actors when they successfully authenticate.

#### Encrypting for readers with different keys

The encrypted salary data needs to be independently decrypted by users with different roles. To accomplish this, we:

1. randomly generate a symmetric key `K` that we'll use for the salary field;
2. for each role that can read salaries, use the role's public key to make an encrypted copy of `K`;
3. in the access control document, include a dictionary mapping roles to the corresponding symmetric key.

Now to decrypt salary data, an actor first finds and decrypts the key corresponding to their role; then uses that key to decrypt the data itself.

### Enforcing `read` permissions

In our example scenario, Dan isn't allowed to see agents (document-level permissions) or salaries (field-level permissions).

When Alice synchronizes with Dan, she has two ways to hide information from him:

1.  **Omission:** Alice can choose to share some documents but not others. This is how we enforce
    **document-level permissions**: Alice can share nothing but civilian records with Dan, and
    that's all he'll ever see.

2.  **Encryption:** Alice can encrypt the contents of individual fields. This is how we enforce
    **field-level permissions**: Alice can encrypt the contents of the salary field using a key that
    Dan doesn't have, but that authorized readers (Carol, Frank, and Gloria) do.

In a client/server setup, read permissions are typically enforced by omission; so that's the model we're familiar with.

In our distributed network, this works for document-level permissions. But Automerge does its magic by keeping the history of an entire document in sync. So any sensitive information _within_ a document needs to be passed around in encrypted form, such that everyone can see it's there, resolve conflicting versions, and so on; but only authorized readers can decrypt it.

### Enforcing `write` permissions

In a client/server model, enforcing write permissions is straightforward, since a central server can simply reject changes coming from unauthorized clients.

In this distributed model, changes might be passed from one actor to another several times before we receive them. Suppose Alice receives Bob's changes via Carol. She needs to be confident that Carol hasn't modified those changes before passing them on. In fact, she needs to be confident that Carol isn't making her own changes and claiming they're Bob's!

To properly enforce `write` permissions, each actor needs to digitally sign their own changes. Step by step:

1. Bob changes Aldrich Ames' salary.
2. Bob signs the change using his private key.
3. Bob goes online; Carol happens to be online as well.
4. Carol and Bob sync up; Carol receives Bob's change.
5. Carol looks up Bob's public key in the access control document and uses it to verify the signed
   change; it checks out.
6. Carol also checks the access control document to verify that Bob has write permissions for the
   salary field; he does.
7. Satisfied, Carol adds the change to her append-only log, and updates her snapshot of Aldrich's
   record.
8. Bob goes offline.
9. Alice comes online and connects to Carol.
10. Alice and Carol sync up; Alice receives Bob's change from Carol.
11. Alice verifies the signature to be sure Bob made the change, and confirms that Bob had
    permission to make the change. She updates her own records as well.

If at any point one of these checks fails - say Carol was trying to pass off her changes as Bob's, or Bob didn't have the right permissions - the receiving actor can simply ignore the change.

> In either situation, it may make sense to also raise some sort of alarm ("Bob is misbehaving", or "Carol is trying to impersonate Bob") that would be handled at the application level.

### Enforcing admin permissions

Only admins can edit the authorization rules for a repository. This is enforced by treating the access control document as read-only for anyone not in an `admin` role: Changes by unauthorized actors will be rejected by other actors.

## Revoking or downgrading permissions

> **A note about reality:** Alice has disclosed information to Bob, she can't exactly _un_-disclose it. Also, unless she has complete control over Bob's computing environment, she can't really prevent Bob from copying and/or distributing the information: He could make a backup onto a thumb drive or a cloud server, or he could send a copy to the New York Times or to the Russians, etc.
> The most any system can promise with regard to information an actor should no longer see is:
>
> - try to erase the information that we've cached or persisted on their devices
> - keep them from receiving any new information in the future

Revoking **write permissions** at any level, and **read permissions** at the **document level**, is a matter of applying the new rules going forward (and in the case of read permissions, removing the newly disallowed documents are removed from the storage we control on the actor's device).

The tricky part is revoking **read permissions** at the **field level**, because of the way we [encrypt for readers with different keys](#encrypting-for-readers-with-different-keys).

As an example, let's suppose Gloria is demoted from from `civilian-manager` to `civilian`, and as a result she should no longer see salary information.

The first thing we do is to regenerate encryption keys for the `civilian-manager` role, and we re-encrypt the salary key for `civilian-manager`. This way Gloria can no longer access the symmetric key used to encrypt salary data.

For many applications, this is be sufficient. If we're really worried, though, we need regenerate that symmetric key and re-encrypt all the salary data. (Technically Gloria has 'seen' the symmetric key, since she's decrypted it in the past any time she's needed to see salary data.)

<h2 id='Access-control-document'>Access control document</h2>

We encode the information about [roles and permissions](https:_github.com_DevResults_cevitxe_issues_37#roles) and the list of [authorized actors and their roles](https:__github.com_DevResults_cevitxe_issues_37#actors) in a special JSON document that is included in the repo under a reserved key.

This document is included with the repository, digitally signed with the root key, and replicated in plaintext to all actors.

For example:

```json
{
  "CEVITXE_ACCESS-CONTROL": {
    "roles": {
      "hr": { "isAdmin": true },
      "it": { "isAdmin": true },
      "civilian-hr": {
        "documentExclusions": { "read": ["agent"] }
      },
      "civilian-manager": {
        "documentExclusions": { "read": ["agent"] },
        "fieldExclusions": { "write": ["salary"] }
      },
      "civilian": {
        "documentExclusions": { "read": ["agent"] },
        "fieldExclusions": { "read": ["salary"], "write": ["salary"] }
      },
      "auditor": {
        "fieldExclusions": { "write": "*" }
      },
      "connector": {}
    },
    "actors": {
      "Alice": { "role": "hr", "publicKey": "51abN…" },
      "Bob": { "role": "it", "publicKey": "12KK0…" },
      "Carol": { "role": "auditor", "publicKey": "4421a…" },
      "Dan": { "role": "civilian", "publicKey": "AA292…" },
      "Frank": { "role": "civilian-hr", "publicKey": "29A32…" },
      "Gloria": { "role": "civilian-manager", "publicKey": "999ZZ…" },
      "ImNotAServer": { "role": "connector", "publicKey": "39220…" }
    },
    "documentExclusions": {
      "agent": "[?(@.jobTitle!=='Agent')]"
    },
    "fieldExclusions": {
      "salary": {
        "path": "salary",
        "keys": {
          "hr": "g*Lß|º}þbóüA…",
          "it": "¹6úí*zïóYÜáQÒ…",
          "civilian-hr": "?26ïtm#êéH)…",
          "auditor": "JR¢L²ÈÜ<ë3?&^Ù…"
        }
      }
    },
    "signature": "skdfDSFJD23847…"
  }
  // ... repository documents follow
}
```

> Note: In the examples, we're referring to actors and roles using readable names like `Alice` and `civilian`. In practice, we can avoid leaking information by using random IDs for both. The human-readable labels can be linked to those IDs in a separate system, or included in the document itself as encrypted metatada.
>
> ```js
> "actors": {
>   "123abc": {
>     "name": "$§1k±ÕáÒ", // "Alice", encrypted
>     "role": "hr",
>     "publicKey": "51abN…"
>   },
>   //...
> ```

### Schema

An access control document has the following root-level elements:

#### `roles`

Dictionary mapping unique IDs to role definitions. A role definition can have the following elements:

- `isAdmin` (boolean; defaults to `false`) indicates a role with no read or write restrictions, and with the ability to modify the access control document.

  ```js
    "hr": { "isAdmin": true }
  ```

  Normally this

- `documentExclusions` and `fieldExclusions` (object; defaults to `{}`) has `read` and `write` properties, each of which is set to an array of keys from the root-level `documentExclusions` and `fieldExclusions`, respectively.

  ```js
  "civilian": {
    "documentExclusions": { "read": ["agent"] },
    "fieldExclusions": { "read": ["salary"], "write": ["salary"] }
  },
  ```

#### `actors`

Dictionary mapping unique actor IDs to actor definitions. An actor definition can have the following elements:

- `role` is a reference to a role ID from the `roles` element.
- `publicKey` is the shared half of a keypair selected by the actor.

<!-- TODO: how/when is the actor's keypair set?  -->

```js
"actors": {
  "Alice": { "role": "hr", "publicKey": "51abN…" },
  "Bob": { "role": "it", "publicKey": "12KK0…" },
  "Carol": { "role": "auditor", "publicKey": "4421a…" },
  // ...
}
```

#### `documentExclusions`

Dictionary mapping exclusion IDs to [JSONPath](https://www.npmjs.com/package/jsonpath) filter expressions.

```js
"documentExclusions": {
  "agent": "[?(@.jobTitle!=='Agent')]"
},
```

#### `fieldExclusions`

Dictionary mapping exclusion IDs to field exclusion definitions. A field exclusion definition has two elements:

- `path` is a JSONPath expression identifying the sensitive property. For properties at the root of the document, this will just be the name of the property.
- `keys` is a dictionary mapping TODO

```js
"fieldExclusions": {
  "salary": {
    "path": "salary",
    "keys": {
      "hr": "g*Lß|º}þbóüA…",
      "it": "¹6úí*zïóYÜáQÒ…",
      "civilian-hr": "?26ïtm#êéH)…",
      "auditor": "JR¢L²ÈÜ<ë3?&^Ù…"
    }
  }
```

#### `signature`

The entire access control document is signed with the repository's root private key, and can be verified against the repository's root public key (provided by the signal server when connecting peers).
