### PR TITLE
Add display order to grid example

### DIFF
--- a/packages/examples/grid/src/ag-grid/buildColumnFromSchema.ts
+++ b/packages/examples/grid/src/ag-grid/buildColumnFromSchema.ts
@@ -2,13 +2,19 @@
 
 export const buildColumnFromSchema = (field: string, schema: any) => {
   const colDef: ColDef = { field }
-  if (schema.description) {
-    colDef.headerName = schema.description
-  }
+
+  // Use description if present
+  if (schema.description) colDef.headerName = schema.description
+
+  // Default sort = displayOrder
+  if (field === 'displayOrder') colDef.sort = 'asc'
+
+  // Our only non-text column type for now
   switch (schema.type) {
     case 'number':
       colDef.type = 'numericColumn'
       colDef.filter = 'number'
   }
+
   return colDef
 }

--- a/packages/examples/grid/src/components/DataGenerator.tsx
+++ b/packages/examples/grid/src/components/DataGenerator.tsx
@@ -96,5 +96,6 @@ const schema = {
     latitude: {},
     longitude: {},
     paragraph: {},
+    displayOrder: { type: 'number' },
   },
 } as JSONSchema7

--- a/packages/examples/grid/src/redux/actions.ts
+++ b/packages/examples/grid/src/redux/actions.ts
@@ -53,7 +53,7 @@ export const clearCollection = () => ({
   payload: {},
 })
 
-export const addItem = (item: any = { id: uuid() }) => ({
+export const addItem = (item: any = { id: uuid(), displayOrder: Date.now() * 1000 }) => ({
   type: ITEM_ADD,
   payload: item,
 })

--- a/packages/examples/grid/src/utils/randomRow.ts
+++ b/packages/examples/grid/src/utils/randomRow.ts
@@ -1,6 +1,8 @@
 ﻿import uuid from 'uuid'
 import faker from 'faker'
 
+let i = 0
+
 export function randomRow() {
   return {
     id: uuid()
@@ -17,5 +19,6 @@ export function randomRow() {
     latitude: +faker.address.latitude(),
     longitude: +faker.address.longitude(),
     paragraph: faker.lorem.paragraph(),
+    displayOrder: Date.now() * 1000 + (i++ % 1000), // so we sort items created in the same millisecond correctly
   }
 }


### PR DESCRIPTION
fixes #50 

- Adds a DisplayOrder field to generated grid data
- Populates it using a timestamp + a sub-millisecond sequential number, so it matches creation order
    - when generating random data
    - when adding a new row via the UI
- Makes DisplayOrder the default sort column for the grid

To review:
- [ ] follow steps to reproduce in #50 and confirm sort order is now stable
